### PR TITLE
Add final version of SAC as presented at ICML 2018

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -44,7 +44,6 @@ dependencies:
         - cloudpickle
         - Cython
         - redis
-        - keras==1.2.1
         - git+https://github.com/Theano/Theano.git@adfe319ce6b781083d8dc3200fb4481b00853791#egg=Theano
         - git+https://github.com/neocxi/Lasagne.git@484866cf8b38d878e92d521be445968531646bb8#egg=Lasagne
         - git+https://github.com/plotly/plotly.py.git@2594076e29584ede2d09f2aa40a8a195b3f3fc66#egg=plotly
@@ -56,9 +55,7 @@ dependencies:
         - git+https://github.com/neocxi/prettytensor.git
         - jupyter
         - progressbar2
-        - chainer==1.18.0
-        - https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.0.1-cp35-cp35m-linux_x86_64.whl; 'linux' in sys_platform
-        - https://storage.googleapis.com/tensorflow/mac/gpu/tensorflow_gpu-1.0.1-py3-none-any.whl; sys_platform == 'darwin'
+        - tensorflow==1.4
         - numpy-stl==2.2.0
         - nibabel==2.1.0
         - pylru==1.0.9

--- a/examples/mujoco_all_sac.py
+++ b/examples/mujoco_all_sac.py
@@ -7,9 +7,10 @@ import numpy as np
 from rllab.envs.normalized_env import normalize
 from rllab.envs.mujoco.gather.ant_gather_env import AntGatherEnv
 from rllab.envs.mujoco.swimmer_env import SwimmerEnv
-from rllab.envs.mujoco.ant_env import AntEnv
+# from rllab.envs.mujoco.ant_env import AntEnv
 from rllab.envs.mujoco.humanoid_env import HumanoidEnv
 from rllab.misc.instrument import VariantGenerator
+from rllab import config
 
 from sac.algos import SAC
 from sac.envs import (
@@ -22,36 +23,49 @@ from sac.envs import (
 
 from sac.misc.instrument import run_sac_experiment
 from sac.misc.utils import timestamp, unflatten
-from sac.policies import LatentSpacePolicy, GMMPolicy
+from sac.policies import GaussianPolicy, LatentSpacePolicy, GMMPolicy, UniformPolicy
 from sac.misc.sampler import SimpleSampler
 from sac.replay_buffers import SimpleReplayBuffer
 from sac.value_functions import NNQFunction, NNVFunction
 from sac.preprocessors import MLPPreprocessor
-from .variants import parse_domain_and_task, get_variants
+from examples.variants import parse_domain_and_task, get_variants
+
+# remove these for published version
+config.DOCKER_IMAGE = "haarnoja/sac"  # needs psutils
+config.AWS_IMAGE_ID = "ami-a3a8b3da"  # with docker already pulled
 
 ENVIRONMENTS = {
-    'swimmer': {
+    'swimmer-gym': {
+        'default': lambda: GymEnv('Swimmer-v1'),
+    },
+    'swimmer-rllab': {
         'default': SwimmerEnv,
         'multi-direction': MultiDirectionSwimmerEnv,
     },
     'ant': {
-        'default': AntEnv,
+        'default': lambda: GymEnv('Ant-v1'),
         'multi-direction': MultiDirectionAntEnv,
         'cross-maze': CrossMazeAntEnv
     },
-    'humanoid': {
+    'humanoid-gym': {
+        'default': lambda: GymEnv('Humanoid-v1')
+    },
+    'humanoid-rllab': {
         'default': HumanoidEnv,
         'multi-direction': MultiDirectionHumanoidEnv,
     },
     'hopper': {
-        'default': lambda: normalize(GymEnv('Hopper-v1'))
+        'default': lambda: GymEnv('Hopper-v1')
     },
     'half-cheetah': {
-        'default': lambda: normalize(GymEnv('HalfCheetah-v1'))
+        'default': lambda: GymEnv('HalfCheetah-v1')
     },
     'walker': {
-        'default': lambda: normalize(GymEnv('Walker2d-v1'))
+        'default': lambda: GymEnv('Walker2d-v1')
     },
+    'humanoid-standup-gym': {
+        'default': lambda: GymEnv('HumanoidStandup-v1')
+    }
 }
 
 DEFAULT_DOMAIN = DEFAULT_ENV = 'swimmer'
@@ -70,8 +84,8 @@ def parse_args():
                         default='default')
     parser.add_argument('--policy',
                         type=str,
-                        choices=('lsp', 'gmm'),
-                        default='lsp')
+                        choices=('gaussian', 'gmm', 'lsp'),
+                        default='gaussian')
     parser.add_argument('--env', type=str, default=DEFAULT_ENV)
     parser.add_argument('--exp_name', type=str, default=timestamp())
     parser.add_argument('--mode', type=str, default='local')
@@ -100,10 +114,20 @@ def run_experiment(variant):
     base_kwargs = dict(algorithm_params['base_kwargs'], sampler=sampler)
 
     M = value_fn_params['layer_size']
-    qf = NNQFunction(env_spec=env.spec, hidden_layer_sizes=(M, M))
+    qf1 = NNQFunction(env_spec=env.spec, hidden_layer_sizes=(M, M), name='qf1')
+    qf2 = NNQFunction(env_spec=env.spec, hidden_layer_sizes=(M, M), name='qf2')
     vf = NNVFunction(env_spec=env.spec, hidden_layer_sizes=(M, M))
 
-    if policy_params['type'] == 'lsp':
+    initial_exploration_policy = UniformPolicy(env_spec=env.spec)
+
+    if policy_params['type'] == 'gaussian':
+        policy = GaussianPolicy(
+                env_spec=env.spec,
+                hidden_layer_sizes=(M,M),
+                reparameterize=policy_params['reparameterize'],
+                reg=1e-3,
+        )
+    elif policy_params['type'] == 'lsp':
         nonlinearity = {
             None: None,
             'relu': tf.nn.relu,
@@ -133,14 +157,17 @@ def run_experiment(variant):
             env_spec=env.spec,
             squash=policy_params['squash'],
             bijector_config=bijector_config,
-            q_function=qf,
+            reparameterize=policy_params['reparameterize'],
+            q_function=qf1,
             observations_preprocessor=observations_preprocessor)
     elif policy_params['type'] == 'gmm':
+        # reparameterize should always be False if using a GMMPolicy
         policy = GMMPolicy(
             env_spec=env.spec,
             K=policy_params['K'],
             hidden_layer_sizes=(M, M),
-            qf=qf,
+            reparameterize=policy_params['reparameterize'],
+            qf=qf1,
             reg=1e-3,
         )
     else:
@@ -150,13 +177,16 @@ def run_experiment(variant):
         base_kwargs=base_kwargs,
         env=env,
         policy=policy,
+        initial_exploration_policy=initial_exploration_policy,
         pool=pool,
-        qf=qf,
+        qf1=qf1,
+        qf2=qf2,
         vf=vf,
         lr=algorithm_params['lr'],
         scale_reward=algorithm_params['scale_reward'],
         discount=algorithm_params['discount'],
         tau=algorithm_params['tau'],
+        reparameterize=algorithm_params['reparameterize'],
         target_update_interval=algorithm_params['target_update_interval'],
         action_prior=policy_params['action_prior'],
         save_full_state=False,
@@ -178,6 +208,7 @@ def launch_experiments(variant_generator, args):
     for i, variant in enumerate(variants):
         print("Experiment: {}/{}".format(i, num_experiments))
         run_params = variant['run_params']
+        algo_params = variant['algorithm_params']
 
         experiment_prefix = variant['prefix'] + '/' + args.exp_name
         experiment_name = '{prefix}-{exp_name}-{i:02}'.format(

--- a/examples/mujoco_all_sac.py
+++ b/examples/mujoco_all_sac.py
@@ -68,7 +68,7 @@ ENVIRONMENTS = {
     }
 }
 
-DEFAULT_DOMAIN = DEFAULT_ENV = 'swimmer'
+DEFAULT_DOMAIN = DEFAULT_ENV = 'swimmer-rllab'
 AVAILABLE_DOMAINS = set(ENVIRONMENTS.keys())
 AVAILABLE_TASKS = set(y for x in ENVIRONMENTS.values() for y in x.keys())
 

--- a/examples/mujoco_all_sac.py
+++ b/examples/mujoco_all_sac.py
@@ -30,10 +30,6 @@ from sac.value_functions import NNQFunction, NNVFunction
 from sac.preprocessors import MLPPreprocessor
 from examples.variants import parse_domain_and_task, get_variants
 
-# remove these for published version
-config.DOCKER_IMAGE = "haarnoja/sac"  # needs psutils
-config.AWS_IMAGE_ID = "ami-a3a8b3da"  # with docker already pulled
-
 ENVIRONMENTS = {
     'swimmer-gym': {
         'default': lambda: GymEnv('Swimmer-v1'),

--- a/examples/mujoco_all_sac_lsp_hierarchy.py
+++ b/examples/mujoco_all_sac_lsp_hierarchy.py
@@ -12,8 +12,8 @@ from rllab.envs.mujoco.humanoid_env import HumanoidEnv
 from rllab.misc.instrument import VariantGenerator
 
 from sac.algos import SAC
-from sac.envs import (
-    RandomGoalAntEnv, HierarchyProxyEnv)
+# from sac.envs import (
+#     RandomGoalAntEnv, HierarchyProxyEnv)
 from sac.misc.instrument import run_sac_experiment
 from sac.misc.utils import timestamp
 from sac.policies import LatentSpacePolicy
@@ -236,14 +236,16 @@ def load_low_level_policy(policy_path):
 
     return policy
 
-RANDOM_GOAL_ENVS = {
-    'ant': RandomGoalAntEnv,
-}
+# RANDOM_GOAL_ENVS = {
+#     'ant': RandomGoalAntEnv,
+# }
+
 
 RLLAB_ENVS = {
     'ant-rllab': AntEnv,
     'humanoid-rllab': HumanoidEnv
 }
+
 
 def run_experiment(variant):
     low_level_policy = load_low_level_policy(

--- a/examples/multigoal_sac.py
+++ b/examples/multigoal_sac.py
@@ -9,6 +9,7 @@ from sac.misc.plotter import QFPolicyPlotter
 from sac.misc.utils import timestamp
 from sac.policies import GMMPolicy, LatentSpacePolicy
 from sac.replay_buffers import SimpleReplayBuffer
+from sac.misc.sampler import SimpleSampler
 from sac.value_functions import NNQFunction, NNVFunction
 
 
@@ -20,17 +21,13 @@ def run(variant):
         init_sigma=0.1,
     ))
 
-    pool = SimpleReplayBuffer(
-        max_replay_buffer_size=1e6,
-        env_spec=env.spec,
-    )
-
+    pool = SimpleReplayBuffer(max_replay_buffer_size=1e6, env_spec=env.spec)
+    sampler = SimpleSampler(
+        max_path_length=30, min_pool_size=100, batch_size=64)
     base_kwargs = dict(
-        min_pool_size=30,
+        sampler=sampler,
         epoch_length=1000,
         n_epochs=1000,
-        max_path_length=30,
-        batch_size=64,
         n_train_repeat=1,
         eval_render=True,
         eval_n_episodes=10,

--- a/examples/variants.py
+++ b/examples/variants.py
@@ -46,7 +46,7 @@ LSP_POLICY_PARAMS = {
         'preprocessing_hidden_sizes': (M, M, 34),
         's_t_units': 17,
     },
-    'humanoid-rllab': { # 21 DoF 
+    'humanoid-rllab': { # 21 DoF
         'preprocessing_hidden_sizes': (M, M, 42),
         's_t_units': 21,
     }
@@ -303,7 +303,7 @@ DOMAINS = [
     'walker', # 6 DoF
     'ant', # 8 DoF
     'humanoid-gym', # 17 DoF # gym_humanoid
-    'humanoid-rllab', # 21 DoF 
+    'humanoid-rllab', # 21 DoF
     'humanoid-standup-gym', # 17 DoF # gym_humanoid
 ]
 

--- a/examples/variants.py
+++ b/examples/variants.py
@@ -208,51 +208,51 @@ ALGORITHM_PARAMS = {
     'swimmer-rllab': { # 2 DoF
         'scale_reward': 25,
         'base_kwargs': {
-            'n_epochs': int(1e3 + 1),
+            'n_epochs': 1e3,
         }
     },
     'hopper': { # 3 DoF
         'scale_reward': 5,
         'base_kwargs': {
-            'n_epochs': int(3e3 + 1),
+            'n_epochs': 1e3,
         }
     },
     'half-cheetah': { # 6 DoF
         'scale_reward': 5,
         'base_kwargs': {
-            'n_epochs': int(3e3 + 1),
+            'n_epochs': 3e3,
             'n_initial_exploration_steps': 10000,
         }
     },
     'walker': { # 6 DoF
         'scale_reward': 5,
         'base_kwargs': {
-            'n_epochs': int(3e3 + 1),
+            'n_epochs': 1e3,
         }
     },
     'ant': { # 8 DoF
         'scale_reward': 5,
         'base_kwargs': {
-            'n_epochs': int(3e3 + 1),
+            'n_epochs': 3e3,
             'n_initial_exploration_steps': 10000,
         }
     },
     'humanoid-gym': { # 17 DoF
         'scale_reward': 20,
         'base_kwargs': {
-            'n_epochs': int(1e4 + 1),
+            'n_epochs': 1e4,
         }
     },
     'humanoid-rllab': { # 21 DoF
         'scale_reward': 10,
         'base_kwargs': {
-            'n_epochs': int(1e4 + 1),
+            'n_epochs': 1e4,
         }
     },
     'humanoid-standup-gym': { # 17 DoF
         'scale_reward': 100,
         'base_kwargs': {
-            'n_epochs': int(1e4 + 1),
+            'n_epochs': 1e4,
         }
     },
 }

--- a/examples/variants.py
+++ b/examples/variants.py
@@ -275,7 +275,7 @@ RUN_PARAMS_BASE = {
 }
 
 RUN_PARAMS = {
-    'swimmer': { # 2 DoF
+    'swimmer-rllab': { # 2 DoF
         'snapshot_gap': 200
     },
     'hopper': { # 3 DoF
@@ -290,9 +290,12 @@ RUN_PARAMS = {
     'ant': { # 8 DoF
         'snapshot_gap': 2000
     },
-    'humanoid': { # 21 DoF
+    'humanoid-gym': { # 21 DoF
         'snapshot_gap': 4000
-    }
+    },
+    'humanoid-rllab': { # 21 DoF
+        'snapshot_gap': 4000
+    },
 }
 
 

--- a/examples/variants.py
+++ b/examples/variants.py
@@ -3,52 +3,65 @@ import numpy as np
 from rllab.misc.instrument import VariantGenerator
 from sac.misc.utils import flatten, get_git_rev, deep_update
 
+M = 256
+REPARAMETERIZE = True
+
 LSP_POLICY_PARAMS_BASE = {
     'type': 'lsp',
     'coupling_layers': 2,
     's_t_layers': 1,
-    'action_prior': 'normal',
+    'action_prior': 'uniform',
     # 'preprocessing_hidden_sizes': None,
     'preprocessing_output_nonlinearity': 'relu',
+    'reparameterize': REPARAMETERIZE,
     'squash': True
 }
 
 LSP_POLICY_PARAMS = {
-    'swimmer': { # 2 DoF
-        'preprocessing_hidden_sizes': (128, 128, 4),
+    'swimmer-gym': { # 2 DoF
+        'preprocessing_hidden_sizes': (M, M, 4),
+        's_t_units': 2,
+    },
+    'swimmer-rllab': { # 2 DoF
+        'preprocessing_hidden_sizes': (M, M, 4),
         's_t_units': 2,
     },
     'hopper': { # 3 DoF
-        'preprocessing_hidden_sizes': (128, 128, 6),
+        'preprocessing_hidden_sizes': (M, M, 6),
         's_t_units': 3,
     },
     'half-cheetah': { # 6 DoF
-        'preprocessing_hidden_sizes': (128, 128, 12),
+        'preprocessing_hidden_sizes': (M, M, 12),
         's_t_units': 6,
     },
     'walker': { # 6 DoF
-        'preprocessing_hidden_sizes': (128, 128, 12),
+        'preprocessing_hidden_sizes': (M, M, 12),
         's_t_units': 6,
-    },
+   },
     'ant': { # 8 DoF
-        'preprocessing_hidden_sizes': (128, 128, 16),
+        'preprocessing_hidden_sizes': (M, M, 16),
         's_t_units': 8,
     },
-    'humanoid': { # 21 DoF
-        'preprocessing_hidden_sizes': (128, 128, 42),
+    'humanoid-gym': { # 17 DoF
+        'preprocessing_hidden_sizes': (M, M, 34),
+        's_t_units': 17,
+    },
+    'humanoid-rllab': { # 21 DoF 
+        'preprocessing_hidden_sizes': (M, M, 42),
         's_t_units': 21,
     }
 }
 
 GMM_POLICY_PARAMS_BASE = {
     'type': 'gmm',
-    'K': 4,
+    'K': 1,
     'reg': 1e-3,
     'action_prior': 'uniform',
+    'reparameterize': REPARAMETERIZE
 }
 
 GMM_POLICY_PARAMS = {
-    'swimmer': { # 2 DoF
+    'swimmer-rllab': { # 2 DoF
     },
     'hopper': { # 3 DoF
     },
@@ -58,8 +71,38 @@ GMM_POLICY_PARAMS = {
     },
     'ant': { # 8 DoF
     },
-    'humanoid': { # 21 DoF
-    }
+    'humanoid-gym': { # 17 DoF
+    },
+    'humanoid-rllab': { # 21 DoF
+    },
+    'humanoid-standup-gym': { # 17 DoF
+    },
+}
+
+GAUSSIAN_POLICY_PARAMS_BASE = {
+    'type': 'gaussian',
+    'reg': 1e-3,
+    'action_prior': 'uniform',
+    'reparameterize': REPARAMETERIZE
+}
+
+GAUSSIAN_POLICY_PARAMS = {
+    'swimmer-rllab': { # 2 DoF
+    },
+    'hopper': { # 3 DoF
+    },
+    'half-cheetah': { # 6 DoF
+    },
+    'walker': { # 6 DoF
+    },
+    'ant': { # 8 DoF
+    },
+    'humanoid-gym': { # 17 DoF
+    },
+    'humanoid-rllab': { # 21 DoF
+    },
+    'humanoid-standup-gym': { # 17 DoF
+    },
 }
 
 POLICY_PARAMS = {
@@ -71,15 +114,18 @@ POLICY_PARAMS = {
         k: dict(GMM_POLICY_PARAMS_BASE, **v)
         for k, v in GMM_POLICY_PARAMS.items()
     },
+    'gaussian': {
+        k: dict(GAUSSIAN_POLICY_PARAMS_BASE, **v)
+        for k, v in GAUSSIAN_POLICY_PARAMS.items()
+    },
 }
 
 VALUE_FUNCTION_PARAMS = {
-    'layer_size': 128,
-
+    'layer_size': M,
 }
 
 ENV_DOMAIN_PARAMS = {
-    'swimmer': { # 2 DoF
+    'swimmer-rllab': { # 2 DoF
     },
     'hopper': { # 3 DoF
     },
@@ -89,12 +135,16 @@ ENV_DOMAIN_PARAMS = {
     },
     'ant': { # 8 DoF
     },
-    'humanoid': { # 21 DoF
-    }
+    'humanoid-gym': { # 17 DoF
+    },
+    'humanoid-rllab': { # 21 DoF
+    },
+    'humanoid-standup-gym': { # 17 DoF
+    },
 }
 
 ENV_PARAMS = {
-    'swimmer': { # 2 DoF
+    'swimmer-rllab': { # 2 DoF
     },
     'hopper': { # 3 DoF
     },
@@ -124,24 +174,30 @@ ENV_PARAMS = {
             'pre_trained_policy_path': []
         },
     },
-    'humanoid': { # 21 DoF
+    'humanoid-gym': { # 17 DoF
         'resume-training': {
             'low_level_policy_path': [
                 # 'humanoid-low-level-policy-00-00/itr_4000.pkl',
             ]
         }
-    }
+    },
+    'humanoid-rllab': { # 21 DOF
+    },
+    'humanoid-standup-gym': { # 17 DoF
+    },
 }
 
 ALGORITHM_PARAMS_BASE = {
     'lr': 3e-4,
     'discount': 0.99,
     'target_update_interval': 1,
-    'tau': 1e-2,
+    'tau': 0.005,
+    'reparameterize': REPARAMETERIZE,
 
     'base_kwargs': {
         'epoch_length': 1000,
         'n_train_repeat': 1,
+        'n_initial_exploration_steps': 1000,
         'eval_render': False,
         'eval_n_episodes': 1,
         'eval_deterministic': True,
@@ -149,42 +205,56 @@ ALGORITHM_PARAMS_BASE = {
 }
 
 ALGORITHM_PARAMS = {
-    'swimmer': { # 2 DoF
-        'scale_reward': 100,
+    'swimmer-rllab': { # 2 DoF
+        'scale_reward': 25,
         'base_kwargs': {
-            'n_epochs': int(5e2 + 1),
+            'n_epochs': int(1e3 + 1),
         }
     },
     'hopper': { # 3 DoF
-        'scale_reward': 1,
+        'scale_reward': 5,
         'base_kwargs': {
             'n_epochs': int(3e3 + 1),
         }
     },
     'half-cheetah': { # 6 DoF
-        'scale_reward': 1,
+        'scale_reward': 5,
+        'base_kwargs': {
+            'n_epochs': int(3e3 + 1),
+            'n_initial_exploration_steps': 10000,
+        }
+    },
+    'walker': { # 6 DoF
+        'scale_reward': 5,
+        'base_kwargs': {
+            'n_epochs': int(3e3 + 1),
+        }
+    },
+    'ant': { # 8 DoF
+        'scale_reward': 5,
+        'base_kwargs': {
+            'n_epochs': int(3e3 + 1),
+            'n_initial_exploration_steps': 10000,
+        }
+    },
+    'humanoid-gym': { # 17 DoF
+        'scale_reward': 20,
         'base_kwargs': {
             'n_epochs': int(1e4 + 1),
         }
     },
-    'walker': { # 6 DoF
-        'scale_reward': 3,
-        'base_kwargs': {
-            'n_epochs': int(5e3 + 1),
-        }
-    },
-    'ant': { # 8 DoF
+    'humanoid-rllab': { # 21 DoF
         'scale_reward': 10,
         'base_kwargs': {
             'n_epochs': int(1e4 + 1),
         }
     },
-    'humanoid': { # 21 DoF
-        'scale_reward': 3,
+    'humanoid-standup-gym': { # 17 DoF
+        'scale_reward': 100,
         'base_kwargs': {
-            'n_epochs': int(2e4 + 1),
+            'n_epochs': int(1e4 + 1),
         }
-    }
+    },
 }
 
 REPLAY_BUFFER_PARAMS = {
@@ -194,28 +264,51 @@ REPLAY_BUFFER_PARAMS = {
 SAMPLER_PARAMS = {
     'max_path_length': 1000,
     'min_pool_size': 1000,
-    'batch_size': 128,
+    'batch_size': 256,
 }
 
-RUN_PARAMS = {
+RUN_PARAMS_BASE = {
     'seed': [1,2,3,4,5],
     'snapshot_mode': 'gap',
     'snapshot_gap': 1000,
     'sync_pkl': True,
 }
 
+RUN_PARAMS = {
+    'swimmer': { # 2 DoF
+        'snapshot_gap': 200
+    },
+    'hopper': { # 3 DoF
+        'snapshot_gap': 600
+    },
+    'half-cheetah': { # 6 DoF
+        'snapshot_gap': 2000
+    },
+    'walker': { # 6 DoF
+        'snapshot_gap': 1000
+    },
+    'ant': { # 8 DoF
+        'snapshot_gap': 2000
+    },
+    'humanoid': { # 21 DoF
+        'snapshot_gap': 4000
+    }
+}
+
 
 DOMAINS = [
-    'swimmer', # 2 DoF
+    'swimmer-rllab', # 2 DoF
     'hopper', # 3 DoF
     'half-cheetah', # 6 DoF
     'walker', # 6 DoF
     'ant', # 8 DoF
-    'humanoid', # 21 DoF
+    'humanoid-gym', # 17 DoF # gym_humanoid
+    'humanoid-rllab', # 21 DoF 
+    'humanoid-standup-gym', # 17 DoF # gym_humanoid
 ]
 
 TASKS = {
-    'swimmer': [
+    'swimmer-rllab': [
         'default',
         'multi-direction',
     ],
@@ -234,9 +327,15 @@ TASKS = {
         'cross-maze'
 
     ],
-    'humanoid': [
+    'humanoid-gym': [
+        'default',
+    ],
+    'humanoid-rllab': [
         'default',
         'multi-direction'
+    ],
+    'humanoid-standup-gym': [
+        'default',
     ],
 }
 
@@ -262,7 +361,7 @@ def get_variants(domain, task, policy):
         ),
         'replay_buffer_params': REPLAY_BUFFER_PARAMS,
         'sampler_params': SAMPLER_PARAMS,
-        'run_params': RUN_PARAMS,
+        'run_params': deep_update(RUN_PARAMS_BASE, RUN_PARAMS[domain]),
     }
 
     # TODO: Remove flatten. Our variant generator should support nested params

--- a/sac/algos/base.py
+++ b/sac/algos/base.py
@@ -46,7 +46,7 @@ class RLAlgorithm(Algorithm):
         """
         self.sampler = sampler
 
-        self._n_epochs = n_epochs
+        self._n_epochs = int(n_epochs)
         self._n_train_repeat = n_train_repeat
         self._epoch_length = epoch_length
         self._n_initial_exploration_steps = n_initial_exploration_steps

--- a/sac/distributions/__init__.py
+++ b/sac/distributions/__init__.py
@@ -1,2 +1,3 @@
+from .normal import Normal
 from .gmm import GMM
 from .real_nvp_bijector import RealNVPBijector

--- a/sac/distributions/normal.py
+++ b/sac/distributions/normal.py
@@ -1,0 +1,93 @@
+""" Multivariate normal distribution with mean and std deviation outputted by a neural net """
+
+import tensorflow as tf
+import numpy as np
+
+from sac.misc.mlp import mlp
+
+LOG_SIG_CAP_MAX = 2
+LOG_SIG_CAP_MIN = -20
+
+
+class Normal(object):
+    def __init__(
+            self,
+            Dx,
+            hidden_layers_sizes=(100, 100),
+            reg=0.001,
+            reparameterize=True,
+            cond_t_lst=(),
+    ):
+        self._cond_t_lst = cond_t_lst
+        self._reg = reg
+        self._layer_sizes = list(hidden_layers_sizes) + [2 * Dx]
+        print(self._layer_sizes)
+        self._reparameterize = reparameterize
+
+        self._Dx = Dx
+
+        self._create_placeholders()
+        self._create_graph()
+
+    def _create_placeholders(self):
+        self._N_pl = tf.placeholder(
+            tf.int32,
+            shape=(),
+            name='N',
+        )
+
+    def _create_graph(self):
+        Dx = self._Dx
+
+        if len(self._cond_t_lst) == 0:
+            mu_and_logsig_t = tf.get_variable(
+                'params', self._layer_sizes[-1],
+                initializer=tf.random_normal_initializer(0, 0.1)
+            )
+        else:
+            mu_and_logsig_t = mlp(
+                inputs=self._cond_t_lst,
+                layer_sizes=self._layer_sizes,
+                output_nonlinearity=None,
+            )  # ... x K*Dx*2+K
+
+        self._mu_t = mu_and_logsig_t[..., :Dx]
+        self._log_sig_t = tf.clip_by_value(mu_and_logsig_t[..., Dx:], LOG_SIG_CAP_MIN, LOG_SIG_CAP_MAX)
+
+        # Tensorflow's multivariate normal distribution supports reparameterization
+        ds = tf.contrib.distributions
+        dist = ds.MultivariateNormalDiag(loc=self._mu_t, scale_diag=tf.exp(self._log_sig_t))
+        x_t = dist.sample()
+        if not self._reparameterize:
+            x_t = tf.stop_gradient(x_t)
+        log_pi_t = dist.log_prob(x_t)
+
+        self._dist = dist
+        self._x_t = x_t
+        self._log_pi_t = log_pi_t
+        
+        reg_loss_t = self._reg * 0.5 * tf.reduce_mean(self._log_sig_t ** 2)
+        reg_loss_t += self._reg * 0.5 * tf.reduce_mean(self._mu_t ** 2)
+        self._reg_loss_t = reg_loss_t
+
+
+
+    @property
+    def log_p_t(self):
+        return self._log_pi_t
+
+    @property
+    def reg_loss_t(self):
+        return self._reg_loss_t
+
+    @property
+    def x_t(self):
+        return self._x_t
+
+    @property
+    def mu_t(self):
+        return self._mu_t
+
+    @property
+    def log_sig_t(self):
+        return self._log_sig_t

--- a/sac/envs/multigoal.py
+++ b/sac/envs/multigoal.py
@@ -127,7 +127,7 @@ class MultiGoalEnv(Env, Serializable):
         self._env_lines = list()
 
         for path in paths:
-            positions = path["env_infos"]["pos"]
+            positions = np.stack([info['pos'] for info in path['env_infos']])
             xx = positions[:, 0]
             yy = positions[:, 1]
             self._env_lines += self._ax.plot(xx, yy, 'b')

--- a/sac/misc/remote_sampler.py
+++ b/sac/misc/remote_sampler.py
@@ -9,6 +9,7 @@ from rllab.misc import logger
 from . import tf_utils
 from .sampler import Sampler, rollout
 
+# TODO: Make the remote sampler correctly use the initial exploration policy, as of now, using this will fail 
 
 class RemoteSampler(Sampler):
     def __init__(self, **kwargs):

--- a/sac/misc/sampler.py
+++ b/sac/misc/sampler.py
@@ -81,6 +81,9 @@ class Sampler(object):
         self.policy = policy
         self.pool = pool
 
+    def set_policy(self, policy):
+        self.policy = policy
+
     def sample(self):
         raise NotImplementedError
 

--- a/sac/policies/__init__.py
+++ b/sac/policies/__init__.py
@@ -1,3 +1,5 @@
 from .nn_policy import NNPolicy
 from .gmm import GMMPolicy
 from .latent_space_policy import LatentSpacePolicy
+from .uniform_policy import UniformPolicy
+from .gaussian_policy import GaussianPolicy

--- a/sac/policies/gaussian_policy.py
+++ b/sac/policies/gaussian_policy.py
@@ -8,45 +8,37 @@ from rllab.misc.overrides import overrides
 from rllab.misc import logger
 from rllab.core.serializable import Serializable
 
-from sac.distributions import GMM
+from sac.distributions import Normal 
 from sac.policies import NNPolicy
 from sac.misc import tf_utils
 
 EPS = 1e-6
 
-class GMMPolicy(NNPolicy, Serializable):
-    """Gaussian Mixture Model policy"""
-    def __init__(self, env_spec, K=2, hidden_layer_sizes=(100, 100), reg=1e-3,
-                 squash=True, reparameterize=False, qf=None, name='gmm_policy'):
+class GaussianPolicy(NNPolicy, Serializable):
+    def __init__(self, env_spec, hidden_layer_sizes=(100, 100), reg=1e-3,
+                 squash=True, reparameterize=True, name='gaussian_policy'):
         """
         Args:
             env_spec (`rllab.EnvSpec`): Specification of the environment
                 to create the policy for.
-            K (`int`): Number of mixture components.
             hidden_layer_sizes (`list` of `int`): Sizes for the Multilayer
                 perceptron hidden layers.
-            reg (`float`): Regularization coeffiecient for the GMM parameters.
-            squash (`bool`): If True, squash the GMM the gmm action samples
+            reg (`float`): Regularization coeffiecient for the Gaussian parameters.
+            squash (`bool`): If True, squash the Gaussian the gmm action samples
                between -1 and 1 with tanh.
-            qf (`ValueFunction`): Q-function approximator.
+            reparameterize ('bool'): If True, gradients will flow directly through
+                the action samples.
         """
         Serializable.quick_init(self, locals())
 
         self._hidden_layers = hidden_layer_sizes
         self._Da = env_spec.action_space.flat_dim
         self._Ds = env_spec.observation_space.flat_dim
-        self._K = K
         self._is_deterministic = False
         self._fixed_h = None
         self._squash = squash
-        self._qf = qf
-        self._reg = reg
-        
-        # We can only reparameterize if there was one component in the GMM,
-        # in which case one should use sac.policies.GaussianPolicy
-        assert not reparameterize 
         self._reparameterize = reparameterize
-
+        self._reg = reg
 
         self.name = name
         self.build()
@@ -55,8 +47,6 @@ class GMMPolicy(NNPolicy, Serializable):
             tf.get_variable_scope().name + "/" + name
         ).lstrip("/")
 
-        # TODO.code_consolidation: This should probably call
-        # `super(GMMPolicy, self).__init__`
         super(NNPolicy, self).__init__(env_spec)
 
     def actions_for(self, observations, latents=None,
@@ -65,16 +55,14 @@ class GMMPolicy(NNPolicy, Serializable):
         name = name or self.name
 
         with tf.variable_scope(name, reuse=reuse):
-            distribution = GMM(
-                K=self._K,
+            distribution = Normal(
                 hidden_layers_sizes=self._hidden_layers,
                 Dx=self._Da,
+                reparameterize=self._reparameterize,
                 cond_t_lst=(observations,),
                 reg=self._reg
             )
-
-            raw_actions = tf.stop_gradient(distribution.x_t)
-
+        raw_actions = distribution.x_t
         actions = tf.tanh(raw_actions) if self._squash else raw_actions
 
         # TODO: should always return same shape out
@@ -87,6 +75,14 @@ class GMMPolicy(NNPolicy, Serializable):
             return actions, log_pis
 
         return actions
+    
+    def log_pis_for(self, actions):
+        if self._squash:
+           raw_actions = tf.atanh(actions) 
+           log_pis = self._distribution.log_prob(raw_actions)
+           log_pis -= self._squash_correction(raw_actions)
+           return log_pis
+        return self._distribution.log_prob(raw_actions)
 
     def build(self):
         self._observations_ph = tf.placeholder(
@@ -95,67 +91,42 @@ class GMMPolicy(NNPolicy, Serializable):
             name='observations',
         )
 
-        self._latents_ph = tf.placeholder(
-            dtype=tf.float32,
-            shape=(None, self._Da),
-            name='latents',
-        )
-
-        self.sample_z = tf.random_uniform([], 0, self._K, dtype=tf.int32)
-
-        # TODO.code_consolidation:
-        # self.distribution is used very differently compared to the
-        # `LatentSpacePolicy`s distribution.
-        # This does not use `self.actions_for` because we need to manually
-        # access e.g. `self.distribution.mus_t`
         with tf.variable_scope(self.name, reuse=tf.AUTO_REUSE):
-            self.distribution = GMM(
-                K=self._K,
+            self.distribution = Normal(
                 hidden_layers_sizes=self._hidden_layers,
                 Dx=self._Da,
+                reparameterize=self._reparameterize,
                 cond_t_lst=(self._observations_ph,),
                 reg=self._reg,
             )
 
         raw_actions = tf.stop_gradient(self.distribution.x_t)
         self._actions = tf.tanh(raw_actions) if self._squash else raw_actions
-        # TODO.code_consolidation:
-        # This should be standardized with LatentSpacePolicy/NNPolicy
-        # self._determistic_actions = self.actions_for(self._observations_ph,
-        #                                              self._latents_ph)
 
     @overrides
     def get_actions(self, observations):
         """Sample actions based on the observations.
 
-        If `self._is_deterministic` is True, returns a greedily sampled action
-        for the observations. If False, return stochastically sampled action.
+        If `self._is_deterministic` is True, returns the mean action for the 
+        observations. If False, return stochastically sampled action.
 
         TODO.code_consolidation: This should be somewhat similar with
         `LatentSpacePolicy.get_actions`.
         """
         if self._is_deterministic: # Handle the deterministic case separately.
-            if self._qf is None: raise AttributeError
 
             feed_dict = {self._observations_ph: observations}
 
             # TODO.code_consolidation: these shapes should be double checked
             # for case where `observations.shape[0] > 1`
-            mus = tf.get_default_session().run(
-                self.distribution.mus_t, feed_dict)[0]  # K x Da
+            mu = tf.get_default_session().run(
+                self.distribution.mu_t, feed_dict)  # 1 x Da
+            if self._squash:
+                mu = np.tanh(mu)
 
-            squashed_mus = np.tanh(mus) if self._squash else mus
-            qs = self._qf.eval(observations, squashed_mus)
+            return mu
 
-            if self._fixed_h is not None:
-                h = self._fixed_h # TODO.code_consolidation: this needs to be tiled
-            else:
-                h = np.argmax(qs) # TODO.code_consolidation: check the axis
-
-            actions = squashed_mus[h, :][None]
-            return actions
-
-        return super(GMMPolicy, self).get_actions(observations)
+        return super(GaussianPolicy, self).get_actions(observations)
 
     def _squash_correction(self, actions):
         if not self._squash: return 0
@@ -176,17 +147,12 @@ class GMMPolicy(NNPolicy, Serializable):
                 deterministic context.
         """
         was_deterministic = self._is_deterministic
-        old_fixed_h = self._fixed_h
 
         self._is_deterministic = set_deterministic
-        if set_deterministic:
-            if latent is None: latent = self.sample_z.eval()
-            self._fixed_h = latent
 
         yield
 
         self._is_deterministic = was_deterministic
-        self._fixed_h = old_fixed_h
 
     def log_diagnostics(self, iteration, batch):
         """Record diagnostic information to the logger.
@@ -197,28 +163,24 @@ class GMMPolicy(NNPolicy, Serializable):
 
         feeds = {self._observations_ph: batch['observations']}
         sess = tf_utils.get_default_session()
-        mus, log_sigs, log_ws, log_pis = sess.run(
+        mu, log_sig, log_pi = sess.run(
             (
-                self.distribution.mus_t,
-                self.distribution.log_sigs_t,
-                self.distribution.log_ws_t,
+                self.distribution.mu_t,
+                self.distribution.log_sig_t,
                 self.distribution.log_p_t,
             ),
             feeds
         )
 
-        logger.record_tabular('gmm-mus-mean', np.mean(mus))
-        logger.record_tabular('gmm-mus-min', np.min(mus))
-        logger.record_tabular('gmm-mus-max', np.max(mus))
-        logger.record_tabular('gmm-mus-std', np.std(mus))
-        logger.record_tabular('gmm-log-w-mean', np.mean(log_ws))
-        logger.record_tabular('gmm-log-w-min', np.min(log_ws))
-        logger.record_tabular('gmm-log-w-max', np.max(log_ws))
-        logger.record_tabular('gmm-log-w-std', np.std(log_ws))
-        logger.record_tabular('gmm-log-sigs-mean', np.mean(log_sigs))
-        logger.record_tabular('gmm-log-sigs-min', np.min(log_sigs))
-        logger.record_tabular('gmm-log-sigs-max', np.max(log_sigs))
-        logger.record_tabular('gmm-log-sigs-std', np.std(log_sigs))
-        logger.record_tabular('log_pi_mean', np.mean(log_pis))
-        logger.record_tabular('log_pi_max', np.max(log_pis))
-        logger.record_tabular('log_pi_min', np.min(log_pis))
+        logger.record_tabular('policy-mus-mean', np.mean(mu))
+        logger.record_tabular('policy-mus-min', np.min(mu))
+        logger.record_tabular('policy-mus-max', np.max(mu))
+        logger.record_tabular('policy-mus-std', np.std(mu))
+        logger.record_tabular('log-sigs-mean', np.mean(log_sig))
+        logger.record_tabular('log-sigs-min', np.min(log_sig))
+        logger.record_tabular('log-sigs-max', np.max(log_sig))
+        logger.record_tabular('log-sigs-std', np.std(log_sig))
+        logger.record_tabular('log-pi-mean', np.mean(log_pi))
+        logger.record_tabular('log-pi-max', np.max(log_pi))
+        logger.record_tabular('log-pi-min', np.min(log_pi))
+        logger.record_tabular('log-pi-std', np.std(log_pi))

--- a/sac/policies/latent_space_policy.py
+++ b/sac/policies/latent_space_policy.py
@@ -22,6 +22,7 @@ class LatentSpacePolicy(NNPolicy, Serializable):
                  mode="train",
                  squash=True,
                  bijector_config=None,
+                 reparameterize=False,
                  observations_preprocessor=None,
                  fix_h_on_reset=False,
                  q_function=None,
@@ -44,6 +45,7 @@ class LatentSpacePolicy(NNPolicy, Serializable):
         self._bijector_config = bijector_config
         self._mode = mode
         self._squash = squash
+        self._reparameterize = reparameterize
         self._fix_h_on_reset = fix_h_on_reset
         self._q_function = q_function
         self._n_map_action_candidates=n_map_action_candidates
@@ -82,7 +84,8 @@ class LatentSpacePolicy(NNPolicy, Serializable):
                 raw_actions = self.distribution.sample(
                     N, bijector_kwargs={"condition": conditions})
 
-            raw_actions = tf.stop_gradient(raw_actions)
+            if not self._reparameterize:
+                raw_actions = tf.stop_gradient(raw_actions)
 
         actions = tf.tanh(raw_actions) if self._squash else raw_actions
 

--- a/sac/policies/uniform_policy.py
+++ b/sac/policies/uniform_policy.py
@@ -1,0 +1,37 @@
+from rllab.core.serializable import Serializable
+
+from rllab.misc.overrides import overrides
+from sandbox.rocky.tf.policies.base import Policy
+
+import numpy as np
+
+
+class UniformPolicy(Policy, Serializable):
+    """
+    Fixed policy that randomly samples actions uniformly at random.
+
+    Used for an initial exploration period instead of an undertrained policy.
+    """
+    def __init__(self, env_spec):
+        Serializable.quick_init(self, locals())
+        self._Da = env_spec.action_space.flat_dim
+
+        super(UniformPolicy, self).__init__(env_spec)
+
+    # Assumes action spaces are normalized to be the interval [-1, 1]
+    @overrides
+    def get_action(self, observation):
+        return np.random.uniform(-1., 1., self._Da), None 
+
+    @overrides
+    def get_actions(self, observations):
+        pass 
+
+    @overrides
+    def log_diagnostics(self, paths):
+        pass
+
+    @overrides
+    def get_params_internal(self, **tags):
+        pass 
+

--- a/sac/value_functions/value_function.py
+++ b/sac/value_functions/value_function.py
@@ -7,7 +7,7 @@ from sac.misc import tf_utils
 
 class NNVFunction(MLPFunction):
 
-    def __init__(self, env_spec, hidden_layer_sizes=(100, 100)):
+    def __init__(self, env_spec, hidden_layer_sizes=(100, 100), name='vf'):
         Serializable.quick_init(self, locals())
 
         self._Do = env_spec.observation_space.flat_dim
@@ -18,11 +18,11 @@ class NNVFunction(MLPFunction):
         )
 
         super(NNVFunction, self).__init__(
-            'vf', (self._obs_pl,), hidden_layer_sizes)
+            name, (self._obs_pl,), hidden_layer_sizes)
 
 
 class NNQFunction(MLPFunction):
-    def __init__(self, env_spec, hidden_layer_sizes=(100, 100)):
+    def __init__(self, env_spec, hidden_layer_sizes=(100, 100), name='qf'):
         Serializable.quick_init(self, locals())
 
         self._Da = env_spec.action_space.flat_dim
@@ -41,7 +41,8 @@ class NNQFunction(MLPFunction):
         )
 
         super(NNQFunction, self).__init__(
-            'qf', (self._obs_pl, self._action_pl), hidden_layer_sizes)
+            name, (self._obs_pl, self._action_pl), hidden_layer_sizes)
+
 
 class NNDiscriminatorFunction(MLPFunction):
     def __init__(self, env_spec, hidden_layer_sizes=(100, 100), num_skills=None):


### PR DESCRIPTION
The main modifications compared to the early version of SAC include
* Use of reparameterization trick to estimate the policy gradient
* Use of two Q-function as in TD3
* Use of a Gaussian policy instead of GMM